### PR TITLE
Fix timestamp conversions 

### DIFF
--- a/ros2_message_converter/message_converter.py
+++ b/ros2_message_converter/message_converter.py
@@ -185,19 +185,19 @@ def _convert_to_ros_time(field_type, field_value):
     time = None
     if field_type == 'builtin_interfaces/Time':
         time = Time()
-        if 'secs' in field_value:
-            setattr(time,'sec',field_value['secs'])
+        if 'sec' in field_value:
+            setattr(time,'sec',field_value['sec'])
             #time = Time(seconds=field_value['secs'])
-        if 'nsecs' in field_value:
-            setattr(time,'nanosec',field_value['nsecs'])
+        if 'nanosec' in field_value:
+            setattr(time,'nanosec',field_value['nanosec'])
             #time = Time(nanoseconds=field_value['nsecs'])
     elif field_type == 'builtin_interfaces/Duration':
         time = Duration()
-        if 'secs' in field_value:
-            setattr(time,'sec',field_value['secs'])
+        if 'sec' in field_value:
+            setattr(time,'sec',field_value['sec'])
             #time = Duration(seconds=field_value['secs'])
-        if 'nsecs' in field_value:
-            setattr(time,'nanosec',field_value['nsecs'])
+        if 'nanosec' in field_value:
+            setattr(time,'nanosec',field_value['nanosec'])
             #time = Duration(nanoseconds=field_value['nsecs'])
         
 
@@ -287,8 +287,8 @@ def _convert_from_ros_binary(field_type, field_value):
 
 def _convert_from_ros_time(field_type, field_value):
     field_value = {
-        'secs'  : field_value.secs,
-        'nsecs' : field_value.nsecs
+        'sec'  : field_value.sec,
+        'nanosec' : field_value.nanosec
     }
     return field_value
 

--- a/ros2_message_converter/message_converter.py
+++ b/ros2_message_converter/message_converter.py
@@ -146,8 +146,8 @@ def _convert_to_ros_type(field_name, field_type, field_value, check_types=True):
         field_value = _convert_to_ros_binary(field_type, field_value)
     elif _is_field_type_binary_type_array(field_type):
         field_value = list(bytearray(base64.b64decode(field_value)))
-    elif field_type in ros_time_types:
-        field_value = _convert_to_ros_time(field_type, field_value)
+    #elif field_type in ros_time_types:
+    #    field_value = _convert_to_ros_time(field_type, field_value)
     elif field_type in ros_primitive_types:
         # Note: one could also use genpy.message.check_type() here, but:
         # 1. check_type is "not designed to run fast and is meant only for error diagnosis"
@@ -247,8 +247,8 @@ def convert_ros_message_to_dictionary(message):
 def _convert_from_ros_type(field_type, field_value):
     if field_type in ros_primitive_types:
         field_value = field_value
-    elif field_type in ros_time_types:
-        field_value = _convert_from_ros_time(field_type, field_value)
+    #elif field_type in ros_time_types:
+    #    field_value = _convert_from_ros_time(field_type, field_value)
     elif _is_ros_binary_type(field_type):
         field_value = _convert_from_ros_binary(field_type, field_value)
     elif _is_field_type_a_primitive_array(field_type):


### PR DESCRIPTION
The current implementation fails to convert timestamps to dicts and back; To reconstruct simply run: 

```python
from geometry_msgs.msg import TransformStamped
from ros2_message_converter import message_converter                                                                                
t = TransformStamped()
d = message_converter.convert_ros_message_to_dictionary(t) 
message_converter.convert_dictionary_to_ros_message('geometry_msgs/TransformStamped', d)
```

This will throw the following AttributeError: 
```
  File "/home/bbferka/work/ros2/scanning_ws/build/ros2_message_converter/ros2_message_converter/message_converter.py", line 290, in _convert_from_ros_time
    'secs'  : field_value.secs,
AttributeError: 'Time' object has no attribute 'secs'
```

This PR addresses this issue by first renaming ``nsecs`` and ``secs`` to ``nanosec`` and ``sec`` respectively and by actually disabling the check for timestamp field_types. In ROS2 Timestamps are just another type of message, so general conversion works fine. 