### PR TITLE
updating ROS Time parsing to use sec and nanosec field names

### DIFF
--- a/ros2_message_converter/message_converter.py
+++ b/ros2_message_converter/message_converter.py
@@ -287,8 +287,8 @@ def _convert_from_ros_binary(field_type, field_value):
 
 def _convert_from_ros_time(field_type, field_value):
     field_value = {
-        'secs'  : field_value.secs,
-        'nsecs' : field_value.nsecs
+        'secs'  : field_value.sec,
+        'nsecs' : field_value.nanosec
     }
     return field_value
 


### PR DESCRIPTION
I believe this addresses the issue raised in https://github.com/mehmetkillioglu/ros2_message_converter/issues/2